### PR TITLE
update dependency from 0.2.0 to 0.3.0 in manager to reflect global ve…

### DIFF
--- a/lib/polymer_app_manager.dart
+++ b/lib/polymer_app_manager.dart
@@ -345,7 +345,7 @@ class PolymerAppManager extends JsonObject {
       "  sdk: '>=1.13.0 <2.0.0'\n\n"
       "dependencies:\n"
       '  polymer: "^1.0.0-rc.10"\n'
-      '  polymer_app: "^0.2.0"\n'
+      '  polymer_app: "^0.3.0"\n'
       '${material ? "  polymer_elements: '^1.0.0-rc.5'\n" : ""}'
       '  polymer_app_router: "^0.0.5"\n'
       '  dart_to_js_script_rewriter: "^0.1.0+4"\n'


### PR DESCRIPTION
Hello,

I installed polymer_app then create a new app with it. Then ran pub get and pub serve.

I got 
Serving essai web on http://localhost:8080
Build completed successfully
[web] GET Served 6 assets.
[Info from Dart2JS]:
Compiling essai|web/index.bootstrap.initialize.dart...
[web] GET Served 2 assets.
[Error from Dart2JS on essai|web/index.bootstrap.initialize.dart]:
web/index_reflectable_original_main.dart:3:1:
Can't read 'package:polymer_app/serializer.dart' (Could not find asset polymer_app|lib/serializer.dart.).
import "package:polymer_app/serializer.dart";
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Warning from Dart2JS on essai|web/index.bootstrap.initialize.dart]:
web/index_reflectable_original_main.dart:6:3:
Cannot resolve 'initSerializer'.
  initSerializer();
  ^^^^^^^^^^^^^^^^
[Dart2JS on essai|web/index.bootstrap.initialize.dart]:
7 warning(s) suppressed in package:polymer_app_router.
[Warning from Dart2JS on essai|web/index.bootstrap.initialize.dart]:
2 hint(s) suppressed in package:reflectable.
[Dart2JS on essai|web/index.bootstrap.initialize.dart]:
1 warning(s) suppressed in package:polymer_app.
[Warning from Dart2JS on essai|web/index.bootstrap.initialize.dart]:
1 hint(s) suppressed in package:initialize.
[Info from Dart2JS]:
Took 0:00:13.705893 to compile essai|web/index.bootstrap.initialize.dart.
Build completed with 1 errors.
[web] GET index.bootstrap.initialize.dart.js → Could not find asset essai|web/index.bootstrap.initialize.dart.js.
[web] GET favicon.ico → Could not find asset essai|web/favicon.ico.

Updating lib/polymer_app_manager.dart to add 0.3.0 in template fix the problem and now "pub serve" works.
